### PR TITLE
milliseconds fix

### DIFF
--- a/lib/src/fhir.dart
+++ b/lib/src/fhir.dart
@@ -13,7 +13,7 @@ extension FhirInstantX on FhirInstant {
     // try with milliseconds first
     try {
       final pattern = OffsetDateTimePattern.createWithInvariantCulture(
-        "uuuu-MM-dd'T'HH:mm:ss.fffo<G>",
+        "uuuu-MM-dd'T'HH:mm:ss.FFFFFFo<G>",
       );
 
       final offsetDateTime = pattern.parse(toString()).value;
@@ -54,7 +54,7 @@ extension FhirDateTimeX on FhirDateTime {
     // try with milliseconds first
     try {
       final pattern = OffsetDateTimePattern.createWithInvariantCulture(
-        "uuuu-MM-dd'T'HH:mm:ss.fffo<G>",
+        "uuuu-MM-dd'T'HH:mm:ss.FFFFFFo<G>",
       );
 
       final offsetDateTime = pattern.parse(toString()).value;


### PR DESCRIPTION
Current way of parsing FhirInstant or FhirDateTime to Instant enforce to use only 3 digits milliseconds, in fact there should be range of acceptable millisceonds (up to 6). This PR ensures this