### PR TITLE
Hotfix in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Publish package
         run: |
-          dart pub lish --force
+          dart pub publish --dry-run

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   publish:
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: 📚 Checkout
         uses: actions/checkout@v5
+
+      - name: 👴🏼 Setup Dart
+        uses: dart-lang/setup-dart@v1
 
       - name: 🗒️ Get version from tag name and edit pubspec accordingly
         id: get_version
@@ -30,5 +33,6 @@ jobs:
           echo "Updated pubspec.yaml:"
           grep "^version:" pubspec.yaml
 
-      - name: 📦 Publish package
-        uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+      - name: Publish package
+        run: |
+          dart pub lish --force

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,4 +34,4 @@ jobs:
           grep "^version:" pubspec.yaml
 
       - name: Publish package
-        run: dart pub publish --dry-run
+        run: dart pub publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,4 +34,4 @@ jobs:
           grep "^version:" pubspec.yaml
 
       - name: Publish package
-        run: dart pub publish
+        run: dart pub publish --force

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,5 +34,4 @@ jobs:
           grep "^version:" pubspec.yaml
 
       - name: Publish package
-        run: |
-          dart pub publish --dry-run
+        run: dart pub publish --dry-run


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances the GitHub Actions publish workflow to set up Dart, derive version from tag to update `pubspec.yaml`, and publish directly with `dart pub publish --force`.
> 
> - **CI (GitHub Actions)**:
>   - **Publish workflow (`.github/workflows/publish.yaml`)**:
>     - Add Dart setup step via `dart-lang/setup-dart@v1`.
>     - Extract version from Git tag and update `pubspec.yaml` before publishing.
>     - Replace reusable publish workflow with direct `dart pub publish --force` command.
>     - Minor: switch tag pattern quotes to double quotes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adb9e030803298d9c9b4bf6bb71f834b414a96cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->